### PR TITLE
fix urls for custom endpoints

### DIFF
--- a/django_rest_generator/client.py
+++ b/django_rest_generator/client.py
@@ -189,7 +189,7 @@ class APIClient(metaclass=ABCMeta):
                 else:
                     base_url = cls.class_url()
 
-                url = f"{base_url}/{endpoint}"
+                url = f"{base_url}{endpoint}"
                 return cls._request(method, url=url, params=params)
 
         setattr(


### PR DESCRIPTION
the current url is object/id//action which returns a 404
it should be object/id/action