### PR TITLE
return an object after generating schema

### DIFF
--- a/django_rest_generator/client.py
+++ b/django_rest_generator/client.py
@@ -270,7 +270,9 @@ class APIClient(metaclass=ABCMeta):
 
     @classmethod
     def build_from_openapi_schema(cls, schema_file, token=None):
-        return cls(token=token)._build_from_openapi_schema(schema_file)
+        obj = cls(token=token)
+        obj._build_from_openapi_schema(schema_file)
+        return obj
 
 
 class GenericApiClient(APIClient):

--- a/django_rest_generator/client.py
+++ b/django_rest_generator/client.py
@@ -269,8 +269,15 @@ class APIClient(metaclass=ABCMeta):
             self.register_resource(resource, resource_class)
 
     @classmethod
-    def build_from_openapi_schema(cls, schema_file, token=None):
-        obj = cls(token=token)
+    def build_from_openapi_schema(cls, schema_file: str = None, *args, **kwargs):
+        """Construct a APIClient from a schema
+
+        :param str schema_file: Optional path to a schema file to load
+        :param *args: arguments required for __init__
+        :param **kwargs: arguments required for __init__
+        :returns APIClient: A populated instance of an APICllient
+        """
+        obj = cls(*args, **kwargs)
         obj._build_from_openapi_schema(schema_file)
         return obj
 


### PR DESCRIPTION
build_from_openapi_schema returns None, so the method also returns None

create the object, populate it, then return the object