### PR TITLE
Fix: Re-writes the all generator mixin to properly fetch all resources and not only the first page.

### DIFF
--- a/django_rest_generator/response.py
+++ b/django_rest_generator/response.py
@@ -15,7 +15,7 @@
 
 import requests
 import json
-
+from typing import Union
 from requests.models import CaseInsensitiveDict
 from django_rest_generator.parser.models import Schema
 
@@ -52,6 +52,18 @@ class APIResponse(object):
             # case: file attachment
             self.file_name = _split_names[1]
             self.raw = self._response.content
+
+    @property
+    def results(self) -> Union[list, dict]:
+        return self.data["results"]
+
+    @property
+    def next_url(self) -> Union[str, None]:
+        return self.data["next"]
+
+    @property
+    def has_next_url(self) -> bool:
+        return self.next_url is not None
 
     def __repr__(self) -> str:
         return f'APIResponse({self._schema}, "{self.url}", {self.code})'


### PR DESCRIPTION
The generator mixin was using an incompatible strategy of always assuming it was a page oriented API. This method resents control back to django to specify what the pagination strategy is and only modifies the query parameters as instructed by the API on the response.