### PR TITLE
Fix: Missing slash on custom endpoint.

### DIFF
--- a/django_rest_generator/client.py
+++ b/django_rest_generator/client.py
@@ -193,7 +193,7 @@ class APIClient(metaclass=ABCMeta):
                 else:
                     base_url = cls.class_url()
 
-                url = f"{base_url}{endpoint}"
+                url = f"{base_url}/{endpoint}/"
                 return cls.make_request(method, url=url, params=params)
 
         setattr(


### PR DESCRIPTION
## Change log
- Adds missing slash between resource endpoint base URL and custom endpoint name.