### PR TITLE
Feat: Add get_or_create mixin

### DIFF
--- a/django_rest_generator/client.py
+++ b/django_rest_generator/client.py
@@ -45,6 +45,7 @@ from .mixins import (
     RetrievableAPIResourceMixin,
     SingletonAPIResourceMixin,
     UpdateableAPIResourceMixin,
+    GetOrCreateAPIResourceMixin,
 )
 from .response import APIResponse
 from .resource import APIResource
@@ -222,7 +223,7 @@ class APIClient(metaclass=ABCMeta):
             "PATCH": [PartiallyUpdateableAPIResourceMixin],
         }
         object_method_map = {
-            "POST": [CreateableAPIResourceMixin],
+            "POST": [CreateableAPIResourceMixin, GetOrCreateAPIResourceMixin],
             "GET": [ListableAPIResourceMixin, PaginationAPIResourceMixin],
             "DELETE": [DeletableObjectResourceMixin],
         }


### PR DESCRIPTION
## Change log
- Adds logging to all request operations for better debugging.
- Adds a `get_or_create` mixin to endpoints that accept `POST` requests.