### PR TITLE
Correct parsing to allow for return type detection

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: coverage-${{ matrix.python-version }}
-        path: .coverage.xml
+        path: ${{ GITHUB_WORKSPACE }}/.coverage.xml
     - name: DEBUG
       run: |
         ls -lart

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Upload artifact, Debug for copilot
       run: |
         echo "Current dir: $(pwd)"
-        echo "Github workspace: $GITHUB_WORKSPACE"
+        echo "Github workspace: $${ GITHUB_WORKSPACE }}"
         echo "Output of ls -la ./.coverage.xml:"
         ls -la ./.coverage.xml
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: coverage-${{ matrix.python-version }}
-        path: ${{ GITHUB_WORKSPACE }}/.coverage.xml
+        path: "${{ GITHUB_WORKSPACE }}/.coverage.xml"
 
   report-coverage:
       runs-on: ubuntu-latest

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -37,6 +37,11 @@ jobs:
       with:
         name: coverage-${{ matrix.python-version }}
         path: .coverage.xml
+    - name: DEBUG
+      run: |
+        ls -lart
+        echo
+        echo $(pwd)
 
   report-coverage:
       runs-on: ubuntu-latest

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -33,16 +33,11 @@ jobs:
     - name: Run the test suite
       run: |
         make test
-    - name: Upload artifact, Debug for copilot
-      run: |
-        echo "Current dir: $(pwd)"
-        echo "Github workspace: ${GITHUB_WORKSPACE}"
-        echo "Output of ls -la ./.coverage.xml:"
-        ls -la ./.coverage.xml
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: coverage-${{ matrix.python-version }}
-        path: "${{ github.workspace }}/.coverage.xml"
+        path: .coverage.xml
+        include-hidden-files: true
 
   report-coverage:
       runs-on: ubuntu-latest

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -35,8 +35,7 @@ jobs:
         make test
     - name: Upload artifact: Debug for copilot
       run: |
-        ls -la ./.coverage.xml
-        echo "Current dir: $(pwd)""
+        echo "Current dir: $(pwd)"
         echo "Github workspace: $GITHUB_WORKSPACE"
         echo "Output of \"ls -la ./.coverage.xml\": $(ls -la ./.coverage.xml)"
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -41,7 +41,8 @@ jobs:
       run: |
         ls -lart
         echo
-        echo $(pwd)
+        echo Current dir: $(pwd)
+        echo Github workspace: $GITHUB_WORKSPACE
 
   report-coverage:
       runs-on: ubuntu-latest

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -35,11 +35,14 @@ jobs:
         make test
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
-        name: coverage
+        name: coverage-${{ matrix.python-version }}
         path: .coverage.xml
 
   report-coverage:
       runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python-version: ["3.10", "3.11", "3.12"]
       needs: [build]
       if: github.event_name == 'pull_request'
       permissions:
@@ -49,7 +52,7 @@ jobs:
         - name: Download tests coverage report
           uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
           with:
-            name: coverage
+            name: coverage-${{ matrix.python-version }}
         - name: Report Coverage and annotate PR (if exists) 
           uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac
           with:

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -33,11 +33,12 @@ jobs:
     - name: Run the test suite
       run: |
         make test
-    - name: "Upload artifact: Debug for copilot"
+    - name: Upload artifact, Debug for copilot
       run: |
         echo "Current dir: $(pwd)"
         echo "Github workspace: $GITHUB_WORKSPACE"
-        echo "Output of \"ls -la ./.coverage.xml\": $(ls -la ./.coverage.xml)"
+        echo "Output of ls -la ./.coverage.xml:"
+        ls -la ./.coverage.xml
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: coverage-${{ matrix.python-version }}

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -36,13 +36,13 @@ jobs:
     - name: Upload artifact, Debug for copilot
       run: |
         echo "Current dir: $(pwd)"
-        echo "Github workspace: $${ GITHUB_WORKSPACE }}"
+        echo "Github workspace: ${GITHUB_WORKSPACE}"
         echo "Output of ls -la ./.coverage.xml:"
         ls -la ./.coverage.xml
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: coverage-${{ matrix.python-version }}
-        path: "${{ GITHUB_WORKSPACE }}/.coverage.xml"
+        path: "${{ github.workspace }}/.coverage.xml"
 
   report-coverage:
       runs-on: ubuntu-latest

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run the test suite
       run: |
         make test
-    - name: Upload artifact: Debug for copilot
+    - name: "Upload artifact: Debug for copilot"
       run: |
         echo "Current dir: $(pwd)"
         echo "Github workspace: $GITHUB_WORKSPACE"

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -33,16 +33,16 @@ jobs:
     - name: Run the test suite
       run: |
         make test
+    - name: Upload artifact: Debug for copilot
+      run: |
+        ls -la ./.coverage.xml
+        echo "Current dir: $(pwd)""
+        echo "Github workspace: $GITHUB_WORKSPACE"
+        echo "Output of \"ls -la ./.coverage.xml\": $(ls -la ./.coverage.xml)"
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: coverage-${{ matrix.python-version }}
         path: ${{ GITHUB_WORKSPACE }}/.coverage.xml
-    - name: DEBUG
-      run: |
-        ls -lart
-        echo
-        echo Current dir: $(pwd)
-        echo Github workspace: $GITHUB_WORKSPACE
 
   report-coverage:
       runs-on: ubuntu-latest

--- a/django_rest_generator/client.py
+++ b/django_rest_generator/client.py
@@ -70,7 +70,7 @@ class APIClient(metaclass=ABCMeta):
         token: str,
         certificate: str = None,
         logger: logging.Logger = None,
-        verify_return_type: bool = True
+        verify_return_type: bool = True,
     ):
         self.__token = token
         self.__certificate = certificate
@@ -275,7 +275,9 @@ class APIClient(metaclass=ABCMeta):
         if schema_file is not None:
             schema = schema_file
 
-        spec = OpenAPISpec.parse(schema, self._server_api_base, verify_return_type=self.__verify_return_type)
+        spec = OpenAPISpec.parse(
+            schema, self._server_api_base, verify_return_type=self.__verify_return_type
+        )
         resources = spec.resources
         self.__schemas = spec.schemas
         # TODO: link these schemas with request/response cycle in order to set them on return.

--- a/django_rest_generator/client.py
+++ b/django_rest_generator/client.py
@@ -70,10 +70,12 @@ class APIClient(metaclass=ABCMeta):
         token: str,
         certificate: str = None,
         logger: logging.Logger = None,
+        verify_return_type: bool = True
     ):
         self.__token = token
         self.__certificate = certificate
         self.__schemas = dict()
+        self.__verify_return_type = verify_return_type
         if logger is not None:
             self._logger = logger
 
@@ -273,7 +275,7 @@ class APIClient(metaclass=ABCMeta):
         if schema_file is not None:
             schema = schema_file
 
-        spec = OpenAPISpec.parse(schema, self._server_api_base)
+        spec = OpenAPISpec.parse(schema, self._server_api_base, verify_return_type=self.__verify_return_type)
         resources = spec.resources
         self.__schemas = spec.schemas
         # TODO: link these schemas with request/response cycle in order to set them on return.

--- a/django_rest_generator/parser/__init__.py
+++ b/django_rest_generator/parser/__init__.py
@@ -112,9 +112,28 @@ class OpenAPISpec:
         return schemas
 
     @classmethod
-    def parse(cls, schema, server_base):
+    def parse(cls, schema, server_base, verify_return_type=True):
         parser = BaseParser(schema)
         spec = parser.specification
         schemas = cls._parse_schemas_from_spec(spec)
         resources = cls._parse_resources_from_openapi(spec, server_base)
+        if not verify_return_type:
+            # Issue #53 caused issues resolving the return_type, resulting in
+            # existing clients working without conversions via the expected
+            # schema types.  The fix may cause clients which previously "worked"
+            # to now fail because of such conversions being imposed.
+            #
+            # See APIResponse._handle_json_response in response.py; it performs
+            # a conversion if the schema is set, and this would result in
+            # errors in case of e.g. mismatches between the OpenAPI spec and the
+            # observed return value from the remote API.
+            #
+            # Typically we would *want* to have such errors due to violation of
+            # the spec, but in case of clients which depended on the old
+            # behavior, verify_return_type=False will "zero-out" the operation
+            # return types so things will work as they did before.
+            for resource in resources:
+                for endpoint in resource.endpoints:
+                    for operation in endpoint.operations:
+                        operation.return_type = None
         return cls(schemas=schemas, resources=resources)

--- a/django_rest_generator/parser/__init__.py
+++ b/django_rest_generator/parser/__init__.py
@@ -15,8 +15,7 @@
 
 from dataclasses import dataclass, make_dataclass
 from typing import List, Any
-from prance import ResolvingParser
-from prance.util.resolver import RESOLVE_HTTP, RESOLVE_FILES, RESOLVE_INTERNAL
+from prance import BaseParser
 from collections import defaultdict
 from django_rest_generator.parser.models import (
     Schema,
@@ -114,7 +113,7 @@ class OpenAPISpec:
 
     @classmethod
     def parse(cls, schema, server_base):
-        parser = ResolvingParser(schema, resolve_types=RESOLVE_HTTP | RESOLVE_FILES | RESOLVE_INTERNAL)
+        parser = BaseParser(schema)
         spec = parser.specification
         schemas = cls._parse_schemas_from_spec(spec)
         resources = cls._parse_resources_from_openapi(spec, server_base)

--- a/django_rest_generator/parser/__init__.py
+++ b/django_rest_generator/parser/__init__.py
@@ -16,7 +16,7 @@
 from dataclasses import dataclass, make_dataclass
 from typing import List, Any
 from prance import ResolvingParser
-from prance.util.resolver import RESOLVE_HTTP, RESOLVE_FILES
+from prance.util.resolver import RESOLVE_HTTP, RESOLVE_FILES, RESOLVE_INTERNAL
 from collections import defaultdict
 from django_rest_generator.parser.models import (
     Schema,
@@ -114,7 +114,7 @@ class OpenAPISpec:
 
     @classmethod
     def parse(cls, schema, server_base):
-        parser = ResolvingParser(schema, resolve_types=RESOLVE_HTTP | RESOLVE_FILES)
+        parser = ResolvingParser(schema, resolve_types=RESOLVE_HTTP | RESOLVE_FILES | RESOLVE_INTERNAL)
         spec = parser.specification
         schemas = cls._parse_schemas_from_spec(spec)
         resources = cls._parse_resources_from_openapi(spec, server_base)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -47,6 +47,20 @@ def test_resource_model_get_schema():
     assert users_resource.get_schema("12/", "PUT") == "User"
 
 
+def test_resource_model_get_schema_with_return_type_verification_disabled():
+    # For backwards compatibility with versions of the library prior to fixing
+    # issue #53.  It does require users of the library to explicitly add
+    # verify_return_type=False to opt in to the previous behavior, since
+    # normally you would want this validation to be turned on.
+    schema = OpenAPISpec.parse(
+        "tests/data/open-api-schema.yaml", "api/v2/", verify_return_type=False
+    )
+    users_resource = schema.resources[0]
+    assert users_resource.get_schema("me/", "GET") == None
+    assert users_resource.get_schema("i/dont/exists", "POST") == None
+    assert users_resource.get_schema("12/", "PUT") == None
+
+
 def test_parser_no_schemas(capsys):
     empty_test_schema = {"components": {"schemas": {}}}
 


### PR DESCRIPTION
Using `prance.ResolvingParser` caused `$ref` references in OpenAPI specs to be replaced automatically with the schemas that they refer to.

However, this library depends on being able to see those `$ref` entries.  It makes better sense to use `prance.BaseParser`, which does not do such substitution, so that our code can see and act on those references itself.

Additionally, for clients which may have been silently broken due to the above behavior - since endpoint return types would have default to None, skipping some of the code related to the parsed spec's return types - this changeset also adds an optional `verify_return_type=True` kwarg to `OpenAPISpec.parse()`; setting it to `False` will cause the code to zero-out the endpoint return values, effectively providing the same behavior as what would have happened when `prance.ResolvingParser` was in use.

Why wasn't this caught before?  There were unit tests, but because `ResolvingParser` was not called with the `RESOLVE_INTERNAL` flag, internal references within the spec file used by the tests would not be replaced by the `ResolvingParser` - leading to this "working" in our tests (since the references we depend on weren't being replaced by prance), but failing when pointed at a spec hosted on a remote web server.

Fixes #53.